### PR TITLE
Posodobljena slika za Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Nastavitvena datoteka za Binder
-FROM jaanos/appr:base
+FROM jaanos/appr:base-2020-09-07
 
 ENV PROJECT_DIR ${HOME}/APPR-2018-19
 ENV PROJECT_FILE ${PROJECT_DIR}/APPR-2018-19.Rproj


### PR DESCRIPTION
Eden od razlogov za #3 je tudi, da uporabljaš lansko sliko za Binder, ki še ni vsebovala knjižnice `tmap`, poleg tega pa sem v novo sliko dodal še knjižnico `countrycode`.

Da se bo uporabila nova slika, sprejmi tale pull request - odpri ga na GitHubu in klikni na **Merge pull request**, nato pa pri sebi naredi *pull*, da pridobiš spremembe.